### PR TITLE
Re-enable Claude workflows after master merge

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Temporarily disabled until workflow is merged to default branch (required for security validation)
-    if: false
+    if: github.event_name == 'pull_request'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   claude:
-    # Temporarily disabled until workflow is merged to default branch (required for security validation)
-    if: false
+    if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'issues' || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/test-fast.sh
+++ b/tests/test-fast.sh
@@ -83,7 +83,10 @@ run_fast_test() {
 
 # Main
 main() {
-    clear
+    # Check if TERM is set and if we can clear the terminal
+    if [ -n "${TERM:-}" ] && [ "$TERM" != "dumb" ] && command -v clear >/dev/null 2>&1; then
+        clear
+    fi
     echo -e "${BLUE}════════════════════════════════════════════════════════════════${NC}"
     echo -e "${CYAN}              FAST DOCKER INTEGRATION TEST                      ${NC}"
     echo -e "${BLUE}════════════════════════════════════════════════════════════════${NC}"


### PR DESCRIPTION
## Summary
- Re-enable Claude code review and interactive workflows that were temporarily disabled during the comprehensive dotfiles overhaul
- Fix terminal compatibility issue in test-fast.sh that was causing CI failures

## What's Changed
- **Enable claude-code-review.yml**: Restore automated PR reviews with proper trigger conditions
- **Enable claude.yml**: Restore interactive Claude responses for issue comments, PR reviews, and issue assignments  
- **Fix terminal compatibility**: Update test-fast.sh to handle CI environments without TERM variable

## Why This Change
The Claude workflows were temporarily disabled with `if: false` during PR #6 because GitHub Actions requires workflows to exist on the default branch before they can run. Now that the comprehensive overhaul has been merged to master, these workflows can be safely re-enabled.

## Technical Details
- Replaced `if: false` with proper event-based conditions
- claude-code-review.yml now triggers on `pull_request` events
- claude.yml triggers on `issue_comment`, `pull_request_review_comment`, `issues`, and `pull_request_review` events
- Added terminal detection to test-fast.sh to prevent CI failures

## Test Plan
- [ ] Verify Claude code review triggers on new PRs
- [ ] Test interactive Claude responses with @claude mentions
- [ ] Confirm CI no longer fails due to TERM environment issues
- [ ] Validate workflow permissions are correctly configured

🤖 Generated with [Claude Code](https://claude.ai/code)